### PR TITLE
feat: updated mantine ui to 6.0.10 (#6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "devDependencies": {
     "@babel/core": "^7.20.2",
     "@emotion/react": "11.10.4",
-    "@mantine/core": "5.4.1",
-    "@mantine/dates": "5.4.1",
-    "@mantine/hooks": "5.4.1",
+    "@mantine/core": "6.0.10",
+    "@mantine/dates": "6.0.10",
+    "@mantine/hooks": "6.0.10",
     "@storybook/addon-actions": "^6.5.13",
     "@storybook/addon-essentials": "^6.5.13",
     "@storybook/addon-interactions": "^6.5.13",

--- a/stories/CheckboxGroup.stories.jsx
+++ b/stories/CheckboxGroup.stories.jsx
@@ -14,20 +14,20 @@ export default {
   },
   argTypes: {
     label: {description: "Label", type: "string"},
-    orientation: {
-      description: "Orientation",
-      control: {
-        type: "select",
-        options: ["horizontal", "vertical"],
-      },
-    },
-    offset: {
-      description: "Offset",
-      control: {
-        type: "select",
-        options: ["xs", "sm", "md", "lg", "xl"],
-      },
-    },
+    // orientation: {
+    //   description: "Orientation",
+    //   control: {
+    //     type: "select",
+    //     options: ["horizontal", "vertical"],
+    //   },
+    // },
+    // offset: {
+    //   description: "Offset",
+    //   control: {
+    //     type: "select",
+    //     options: ["xs", "sm", "md", "lg", "xl"],
+    //   },
+    // },
     spacing: {
       description: "Spacing",
       control: {
@@ -56,9 +56,11 @@ export const Default = (args) => {
       value={value}
       onChange={setValue}
     >
-      {items.map((item) => (
-        <SimpleCheckbox {...item} />
-      ))}
+      <MantineCore.Group spacing={args.spacing} mt="xs">
+        {items.map((item) => (
+          <SimpleCheckbox {...item} />
+        ))}
+      </MantineCore.Group>
     </MantineCore.Checkbox.Group>
   );
 };
@@ -66,8 +68,8 @@ export const Default = (args) => {
 Default.args = {
   label: "Label",
   withAsterisk: false,
-  orientation: "horizontal",
-  offset: "md",
+  // orientation: "horizontal",
+  // offset: "md",
   spacing: "md",
   description: "Description",
   error: "",

--- a/stories/ChipGroup.stories.jsx
+++ b/stories/ChipGroup.stories.jsx
@@ -47,9 +47,11 @@ export const Default = (args) => {
       value={args.multiple? valueMulti : value}
       onChange={args.multiple? setValueMulti : setValue}
     >
-      {items.map((item) => (
-        <SimpleChip {...item} />
-      ))}
+      <MantineCore.Group spacing={args.spacing} position={args.position}>
+        {items.map((item) => (
+          <SimpleChip {...item} />
+        ))}
+      </MantineCore.Group>
     </MantineCore.Chip.Group>
   );
 };

--- a/stories/DatePicker.stories.jsx
+++ b/stories/DatePicker.stories.jsx
@@ -5,7 +5,7 @@ import withIconMapped from "../decorators/withIconMapped";
 
 export default {
   title: "Mantine UI/Date Picker",
-  component: MantineDates.DatePicker,
+  component: MantineDates.DatePickerInput,
   parameters: {
     docs: {
       description: {
@@ -21,6 +21,7 @@ export default {
     disabled: { description: "Disabled", type: "boolean" },
     required: { description: "Required", type: "boolean" },
     multiline: { description: "Multiline", type: "boolean" },
+    clearable: { description: "Clearable", type: "boolean" },
     size: {
       description: "Size",
       control: {
@@ -61,7 +62,7 @@ export default {
 export const Default = (args) => {
   const [value, setValue] = React.useState();
   return (
-    <MantineDates.DatePicker
+    <MantineDates.DatePickerInput
       {...args}
       value={value}
       onChange={setValue}
@@ -79,6 +80,7 @@ Default.args = {
   disabled: false,
   required: false,
   multiline: false,
+  clearable: false,
   size: "md",
   iconName: "IconCalendar",
   iconWidth: 30,

--- a/stories/DateRangePicker.stories.jsx
+++ b/stories/DateRangePicker.stories.jsx
@@ -5,7 +5,7 @@ import withIconMapped from "../decorators/withIconMapped";
 
 export default {
   title: "Mantine UI/Date RangePicker",
-  component: MantineDates.DateRangePicker,
+  component: MantineDates.DatePickerInput,
   parameters: {
     docs: {
       description: {
@@ -51,13 +51,14 @@ export default {
 };
 
 export const Default = (args) => {
-  const [value, onChange] = React.useState(args.defaultValue)
+  const [value, onChange] = React.useState([null, null])
 
   return (
-    <MantineDates.DateRangePicker
+    <MantineDates.DatePickerInput
       {...args}
       value={value}
       onChange={onChange}
+      type="range"
       icon={args.iconName}
       style={{ width: args.width }}
     />

--- a/stories/Notification.stories.jsx
+++ b/stories/Notification.stories.jsx
@@ -51,6 +51,7 @@ export const Default = (args) => {
       {...args}
       icon={args.iconName}
       style={{ width: args.width }}
+      withCloseButton={args.disallowClose}
     >
       {args.description}
     </MantineCore.Notification>

--- a/stories/Radio.stories.jsx
+++ b/stories/Radio.stories.jsx
@@ -38,8 +38,8 @@ export const Default = (args) => {
 Default.args = {
   size: "md",
   label: "Label",
-  description: "description",
-  error: "error",
+  description: "",
+  error: "",
   value: "react",
 };
 

--- a/stories/RadioGroup.stories.jsx
+++ b/stories/RadioGroup.stories.jsx
@@ -17,13 +17,13 @@ export default {
     description: { description: "Description", type: "string" },
     error: { description: "Error", type: "string" },
     required: { description: "Required", type: "boolean" },
-    orientation: {
-      description: "Orientation",
-      control: {
-        type: "select",
-        options: ["horizontal", "vertical"],
-      },
-    },
+    // orientation: {
+    //   description: "Orientation",
+    //   control: {
+    //     type: "select",
+    //     options: ["horizontal", "vertical"],
+    //   },
+    // },
     size: {
       description: "Size",
       control: {
@@ -31,13 +31,13 @@ export default {
         options: ["xs", "sm", "md", "lg", "xl"],
       },
     },
-    offset: {
-      description: "Offset",
-      control: {
-        type: "select",
-        options: ["xs", "sm", "md", "lg", "xl"],
-      },
-    },
+    // offset: {
+    //   description: "Offset",
+    //   control: {
+    //     type: "select",
+    //     options: ["xs", "sm", "md", "lg", "xl"],
+    //   },
+    // },
     spacing: {
       description: "Spacing",
       control: {
@@ -63,7 +63,7 @@ export const Default = (args) => {
       value={value}
       onChange={setValue}
     >
-      <MantineCore.Group>
+      <MantineCore.Group spacing={args.spacing}>
         {items.map((item) => (
           <SimpleRadio key={item.value} {...item} />
         ))}
@@ -77,9 +77,9 @@ Default.args = {
   description: "",
   error: "",
   required: false,
-  orientation: "horizontal",
+  // orientation: "horizontal",
   size: "md",
-  offset: "md",
+  // offset: "md",
   spacing: "md",
   value: "react",
   items: [

--- a/stories/RadioGroup.stories.jsx
+++ b/stories/RadioGroup.stories.jsx
@@ -63,9 +63,11 @@ export const Default = (args) => {
       value={value}
       onChange={setValue}
     >
-      {items.map((item) => (
-        <SimpleRadio {...item} />
-      ))}
+      <MantineCore.Group>
+        {items.map((item) => (
+          <SimpleRadio key={item.value} {...item} />
+        ))}
+      </MantineCore.Group>
     </MantineCore.Radio.Group>
   );
 };

--- a/stories/Select.stories.jsx
+++ b/stories/Select.stories.jsx
@@ -21,6 +21,7 @@ export default {
     required: { description: "Required", type: "boolean" },
     clearable: { description: "Clearable", type: "boolean" },
     initiallyOpened: { description: "Initially opened", type: "boolean" },
+    allowDeselect: { description: "Allow deselect", type: "boolean" },
     dropdownPosition: {
       description: "Dropdown position",
       control: {
@@ -110,6 +111,7 @@ Default.args = {
   required: false,
   clearable: false,
   initiallyOpened: true,
+  allowDeselect: false,
   dropdownPosition: "bottom",
   limit: 100,
   maxDropdownHeight: 500,

--- a/stories/Tabs.stories.jsx
+++ b/stories/Tabs.stories.jsx
@@ -72,7 +72,7 @@ export const Default = (args) => {
 
 Default.args = {
   variant: "pills",
-  orientation: "vertical",
+  orientation: "horizontal",
   defaultValue: "tab1",
   radius: "sm",
   items: [


### PR DESCRIPTION
Some properties have been changed or removed in new mantine ui version.

For example offset and orientation for grupped **checkboxes** and **radios**, for that now we need to to use `Group` component, which has only `orientation` property.

***I haven't deleted changed/removed properties directly, if it is ok what we have now, I will delete them and push**